### PR TITLE
New note fix

### DIFF
--- a/lua/tdo/init.lua
+++ b/lua/tdo/init.lua
@@ -1,7 +1,7 @@
 local tdo = {}
 
 tdo.run_with = function(argument)
-    local full_command = 'tdo ' .. string.format("'%s'", argument)
+    local full_command = 'tdo ' .. argument
     local file_name = vim.fn.system(full_command)
     vim.cmd('edit ' .. file_name)
 end
@@ -12,7 +12,7 @@ tdo.new_note = function()
         local current_time = os.date('%m-%d-%H-%M-%S')
         note = 'drafts/' .. current_time
     end
-    tdo.run_with(note)
+    tdo.run_with(string.format("'%s'", note))
 end
 
 tdo.find_note = function()

--- a/lua/tdo/init.lua
+++ b/lua/tdo/init.lua
@@ -1,7 +1,7 @@
 local tdo = {}
 
 tdo.run_with = function(argument)
-    local full_command = 'tdo ' .. argument
+    local full_command = 'tdo ' .. string.format("'%s'", argument)
     local file_name = vim.fn.system(full_command)
     vim.cmd('edit ' .. file_name)
 end

--- a/lua/tdo/init.lua
+++ b/lua/tdo/init.lua
@@ -12,7 +12,7 @@ tdo.new_note = function()
         local current_time = os.date('%m-%d-%H-%M-%S')
         note = 'drafts/' .. current_time
     end
-    tdo.run(note)
+    tdo.run_with(note)
 end
 
 tdo.find_note = function()


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] Fix a typo when referring to `run_with` function.
- [x] Allow for new note paths with spaces.

## How

What code changes were made to accomplish it?

- Call `tdo.run_with(note)` instead.
- ~~Modify `run_with` and wrap `argument` in a `string.format` function~~
- Wrap `note` in a `string.format` function when calling `run_with` in the `new_note` function.

## Why

- [x] When running `TdoNote` I was facing an error. Screenshot below.
- [x] When adding new note paths with spaces, only the first word was being captured.


## Screenshots (If applicable)

![CleanShot 2024-04-05 at 06 14 59@2x](https://github.com/2KAbhishek/tdo.nvim/assets/20104703/d7c6a960-2208-45f9-8d6e-e24dcf9d050f)

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
