### PR TITLE
Fix pressing Esc still creating entry with new_note

### DIFF
--- a/lua/tdo/init.lua
+++ b/lua/tdo/init.lua
@@ -7,7 +7,10 @@ tdo.run_with = function(argument)
 end
 
 tdo.new_note = function()
-    local note = vim.fn.input('Note Path: ')
+    local note = vim.fn.input({ prompt = 'Note Path: ', cancelreturn = false })
+    if note == false then
+      return
+    end
     if note == '' then
         local current_time = os.date('%m-%d-%H-%M-%S')
         note = 'drafts/' .. current_time


### PR DESCRIPTION
## What

What does this pull request accomplish?

- [x] When pressing `Esc` after triggering `TdoNote`, creating a new note is canceled and does not create a draft. Only upon pressing `Enter`, a new note or a draft is created.

## How

What code changes were made to accomplish it?

- Modify `tdo.new_note`

## Why

- [x] I want to fix the issue #3 

# Checklist

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
